### PR TITLE
The tag for the Docker images is set to the commit hash of the latest…

### DIFF
--- a/.github/workflows/docker-image-build-and-push-to-dockerhub.yml
+++ b/.github/workflows/docker-image-build-and-push-to-dockerhub.yml
@@ -18,10 +18,10 @@ jobs:
       - name: Set up environment variables
         run: |
           if [[ -n $(git diff --name-only ${{ github.base_ref }}...${{ github.head_ref }} -- frontend/) ]]; then
-            echo "IMAGE_TAG_FE=douglasvdmerwe/dev-app-image:$(date +%s)" >> $GITHUB_ENV
+            echo "IMAGE_TAG_FE=douglasvdmerwe/dev-app-image:${{ github.sha }}" >> $GITHUB_ENV
           fi
           if [[ -n $(git diff --name-only ${{ github.base_ref }}...${{ github.head_ref }} -- backend/) ]]; then
-            echo "IMAGE_TAG_BE=douglasvdmerwe/dev-api-image:$(date +%s)" >> $GITHUB_ENV
+            echo "IMAGE_TAG_BE=douglasvdmerwe/dev-api-image:${{ github.sha }}" >> $GITHUB_ENV
           fi
 
       - name: Build the Docker image FE


### PR DESCRIPTION
… commit

The tag for the Docker images is set as ${{ github.sha }}, which represents the commit hash of the latest commit. This ensures that each image has a unique tag associated with the specific commit it was built from. This approach allows you to easily trace back the image to the exact commit in your source code repository.