### PR TITLE
Modify the workflow trigger so that it does not run for every push to…

### DIFF
--- a/.github/workflows/docker-image-build-and-push-to-dockerhub.yml
+++ b/.github/workflows/docker-image-build-and-push-to-dockerhub.yml
@@ -1,13 +1,16 @@
 name: Docker Image CI
 
-on:
+on:  
   push:
     branches:
       - main
+    paths:
+      - 'frontend/**' # Only trigger for changes in the frontend directory
+      - 'backend/**'  # Only trigger for changes in the backend directory
   pull_request:
     branches:
       - main
-
+      
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
… the main branch

The paths keyword is used to define specific file paths or directories that should trigger the workflow. By specifying 'frontend/**' and 'backend/**', the workflow will only be triggered when changes are made within the respective frontend and backend directories.

This way, the workflow will not run for every push to the main branch but only when changes are detected in the frontend or backend directories.